### PR TITLE
Additional fix for custom setting name too long

### DIFF
--- a/force-app/main/default/classes/roundRobinAssigner.cls
+++ b/force-app/main/default/classes/roundRobinAssigner.cls
@@ -1,5 +1,5 @@
 public without sharing class roundRobinAssigner {
-  public static final integer customSettingNameLimitLength = 40;
+  public static final integer customSettingNameLimitLength = 38;
 
   @InvocableMethod(label='Assign objects')
   public static void assign(list<RoundRobinAssignment> rras) {
@@ -77,7 +77,9 @@ public without sharing class roundRobinAssigner {
     RoundRobin__c match,
     list<GroupMember> groupUsers
   ) {
-    if (match.IndexOfLastUsed__c == null) {
+    if (groupUsers.size() == 0) throw new IllegalArgumentException(
+                'Round Robin Assigner: No members of ' + match.GroupName__c + ' found');
+    else if (match.IndexOfLastUsed__c == null) {
       // it's null, so grab the first one!
       return 0;
     } else if (match.IndexOfLastUsed__c >= groupUsers.size() - 1) {
@@ -135,23 +137,17 @@ public without sharing class roundRobinAssigner {
       GroupName.length() +
       2 -
       customSettingNameLimitLength; // for separators
-    if (tooLongness <= 0) {
-      return Obj + '-' + FieldName + '-' + GroupName;
-    }
+    while (tooLongness > 0) {
+      if (Obj.length() > 10) Obj = Obj.left(Obj.length() - 1);
+      if (FieldName.length() > 10) FieldName = FieldName.left(FieldName.length() - 1);
+      if (GroupName.length() > 10) GroupName = GroupName.left(GroupName.length() - 1);
 
-    integer wholesToChop = Math.round(Math.floor(tooLongness / 3));
-    integer remainderToChop = Math.mod(tooLongness, 3);
-
-    Obj = Obj.left(Obj.length() - wholesToChop);
-    FieldName = FieldName.left(FieldName.length() - wholesToChop);
-    GroupName = GroupName.left(GroupName.length() - wholesToChop);
-
-    if (remainderToChop > 0) {
-      GroupName = GroupName.left(GroupName.length() - 1);
-    }
-
-    if (remainderToChop > 1) {
-      FieldName = FieldName.left(FieldName.length() - 1);
+      tooLongness =
+        Obj.length() +
+        FieldName.length() +
+        GroupName.length() +
+        2 -
+        customSettingNameLimitLength;
     }
 
     return Obj + '-' + FieldName + '-' + GroupName;

--- a/force-app/main/default/classes/roundRobinTests.cls
+++ b/force-app/main/default/classes/roundRobinTests.cls
@@ -9,7 +9,7 @@ public with sharing class roundRobinTests {
     );
     // remainder 2
     System.assertEquals(
-      40,
+      38,
       roundRobinAssigner.nameShortener(
           '123456789012345',
           '123456789012345',
@@ -19,7 +19,7 @@ public with sharing class roundRobinTests {
     );
     // remainder 1
     System.assertEquals(
-      40,
+      37,
       roundRobinAssigner.nameShortener(
           '123456789012345',
           '123456789012345',
@@ -29,7 +29,7 @@ public with sharing class roundRobinTests {
     );
     // remainder 0
     System.assertEquals(
-      40,
+      36,
       roundRobinAssigner.nameShortener(
           '123456789012345',
           '12345678901234',
@@ -38,7 +38,7 @@ public with sharing class roundRobinTests {
         .length()
     );
     System.assertEquals(
-      40,
+      38,
       roundRobinAssigner.nameShortener(
           '1234467443456789012345',
           '123456789343487476401234',
@@ -47,7 +47,7 @@ public with sharing class roundRobinTests {
         .length()
     );
     System.assertEquals(
-      40,
+      38,
       roundRobinAssigner.nameShortener(
           'hed__Program_Enrollment__c',
           'cd_Advisor__c',
@@ -55,6 +55,14 @@ public with sharing class roundRobinTests {
         )
         .length()
     );
+    System.assertEquals(
+      38,
+      roundRobinAssigner.nameShortener(
+          '1234467443456789012345',
+          '12345',
+          '1234567893498374348764387638763401234'
+        )
+        .length());
   }
 
   @isTest


### PR DESCRIPTION
Two changes in roundRobinAssigner:

- Changed logic of nameshortener to put the reduction of the custom setting name length in a while loop until it's under 38 characters. This resolves an edge case where one of the three strings (Object Name, Field Name, Group Name) was a great deal longer than the others
- Added an exception to be thrown when the public group being used for assignment has no members. This will also be thrown when the group does not exist.

Change to roundRobinTests to add a test for a particularly long object name.